### PR TITLE
Minor Changes for the UI & Disabling movement when typing

### DIFF
--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -21,6 +21,7 @@ public class PlayerMovement : MonoBehaviour
     }
     public void Move(InputAction.CallbackContext context)
     {
+        if (TypeCastingUI.TypeCastingMode) return;
         movement = context.ReadValue<Vector2>();
 
         if (movement != Vector2.zero)


### PR DESCRIPTION
Removed Enter Button in TypeCastingUI 
- As there's no reason to press enter onced you finish typing the word
- Concept should be similar as monkeytype
- Enter key is what opens/closes the UI

Hence this change would make less code complexity, and would be easier when intergrating this concept into mobile.

What could be improved: 

A counter text that appears when the user typed the word correctly

Fixes 
- Fixed the typecasting UI when typing WSAD Animators still works. Added a one minor line in the PlayerMovement to stop all actions being done in TypeCastingUI